### PR TITLE
Update cache.go

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/gin-contrib/cache/persistence"
-	"github.com/gin-gonic/gin"
+	"gopkg.in/gin-gonic/gin.v1"
 )
 
 const (


### PR DESCRIPTION
change "github.com/gin-gonic/gin" to  "gopkg.in/gin-gonic/gin.v1"
because in the gonic package use "gopkg.in/gin-gonic/gin.v1"

and i have this error while building the project:

```
*/main.go:26: cannot use serveImage (type func(*"gopkg.in/gin-gonic/gin.v1".Context)) as type */gin-gonic/gin".HandlerFunc in argument to "github.com/gin-contrib/cache".CachePage
src/cdn_server/main.go:26: cannot use "github.com/gin-contrib/cache".CachePage(store, time.Minute, serveImage) (type "github.com/gin-gonic/gin".HandlerFunc) as type "gopkg.in/gin-gonic/gin.v1".HandlerFunc in argument to router.RouterGroup.GET

```