### PR TITLE
fix(cache): HTML templates do not work

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -73,8 +73,14 @@ func (w *cachedWriter) Written() bool {
 func (w *cachedWriter) Write(data []byte) (int, error) {
 	ret, err := w.ResponseWriter.Write(data)
 	if err == nil {
-		//cache response
 		store := w.store
+
+		var cache responseCache
+		if err := store.Get(w.key, &cache); err == nil {
+			data = append(cache.data, data...)
+		}
+
+		//cache response
 		val := responseCache{
 			w.status,
 			w.Header(),

--- a/cache.go
+++ b/cache.go
@@ -74,7 +74,6 @@ func (w *cachedWriter) Write(data []byte) (int, error) {
 	ret, err := w.ResponseWriter.Write(data)
 	if err == nil {
 		store := w.store
-
 		var cache responseCache
 		if err := store.Get(w.key, &cache); err == nil {
 			data = append(cache.data, data...)

--- a/cache_test.go
+++ b/cache_test.go
@@ -15,6 +15,7 @@ import (
 func init() {
 	gin.SetMode(gin.TestMode)
 }
+
 func TestCache(t *testing.T) {
 	//TODO:unit test
 }

--- a/example/template.html
+++ b/example/template.html
@@ -1,0 +1,5 @@
+<html>
+<h1>
+    {{ .values }}
+</h1>
+</html>


### PR DESCRIPTION
fix https://github.com/gin-gonic/gin/issues/283. Because c.HTML called ResponseWriter.write multi time internally.

Please review. Thanks.