### PR TITLE
Fix redis serialization error

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -22,9 +22,9 @@ var (
 )
 
 type responseCache struct {
-	status int
-	header http.Header
-	data   []byte
+	Status int
+	Header http.Header
+	Data   []byte
 }
 
 type cachedWriter struct {
@@ -120,13 +120,13 @@ func SiteCache(store persistence.CacheStore, expire time.Duration) gin.HandlerFu
 		if err := store.Get(key, &cache); err != nil {
 			c.Next()
 		} else {
-			c.Writer.WriteHeader(cache.status)
-			for k, vals := range cache.header {
+			c.Writer.WriteHeader(cache.Status)
+			for k, vals := range cache.Header {
 				for _, v := range vals {
 					c.Writer.Header().Add(k, v)
 				}
 			}
-			c.Writer.Write(cache.data)
+			c.Writer.Write(cache.Data)
 		}
 	}
 }
@@ -146,14 +146,14 @@ func CachePage(store persistence.CacheStore, expire time.Duration, handle gin.Ha
 			c.Writer = writer
 			handle(c)
 		} else {
-			log.Println(cache.status)
-			c.Writer.WriteHeader(cache.status)
-			for k, vals := range cache.header {
+			log.Println(cache.Status)
+			c.Writer.WriteHeader(cache.Status)
+			for k, vals := range cache.Header {
 				for _, v := range vals {
 					c.Writer.Header().Add(k, v)
 				}
 			}
-			c.Writer.Write(cache.data)
+			c.Writer.Write(cache.Data)
 		}
 	}
 }


### PR DESCRIPTION
Fixes the redis bug mentioned in this issue from the previous repo: https://github.com/gin-gonic/contrib/issues/29

The responseCache struct has no exported fields and thus cannot be serialized into bytes. This PR makes all the fields exported so that redis caching works.