### PR TITLE
Ignore cors headers

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -127,6 +127,13 @@ func SiteCache(store persistence.CacheStore, expire time.Duration) gin.HandlerFu
 			c.Writer.WriteHeader(cache.Status)
 			for k, vals := range cache.Header {
 				for _, v := range vals {
+					if k == "Content-Encoding" && v == "gzip" {
+						continue
+					}
+					switch k {
+					case "Access-Control-Allow-Credentials", "Access-Control-Allow-Origin", "Access-Control-Expose-Headers", "Vary":
+						continue
+					}
 					c.Writer.Header().Add(k, v)
 				}
 			}
@@ -154,6 +161,10 @@ func CachePage(store persistence.CacheStore, expire time.Duration, handle gin.Ha
 				for _, v := range vals {
 					c.Writer.Header().Add(k, v)
 				}
+			}
+			switch k {
+			case "Access-Control-Allow-Credentials", "Access-Control-Allow-Origin", "Access-Control-Expose-Headers", "Vary":
+				continue
 			}
 			c.Writer.Write(cache.Data)
 		}


### PR DESCRIPTION
the cache interferes with gin CORS, setting the headers twice (once by cache and once by cors), which is invalid.

Thanks to https://github.com/0987363/cache/commit/1882a7e344c628e49df703de9e34b1287c957613