### PR TITLE
Remove debugging

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -143,7 +143,7 @@ func CachePage(store persistence.CacheStore, expire time.Duration, handle gin.Ha
 		url := c.Request.URL
 		key := urlEscape(PageCachePrefix, url.RequestURI())
 		if err := store.Get(key, &cache); err != nil {
-			if err != ErrCacheMiss {
+			if err != persistence.ErrCacheMiss {
 				log.Println(err.Error())
 			}
 			// replace writer

--- a/cache.go
+++ b/cache.go
@@ -143,7 +143,9 @@ func CachePage(store persistence.CacheStore, expire time.Duration, handle gin.Ha
 		url := c.Request.URL
 		key := urlEscape(PageCachePrefix, url.RequestURI())
 		if err := store.Get(key, &cache); err != nil {
-			//log.Println(err.Error())
+			if err != ErrCacheMiss {
+				log.Println(err.Error())
+			}
 			// replace writer
 			writer := newCachedWriter(store, expire, c.Writer, key)
 			c.Writer = writer

--- a/cache.go
+++ b/cache.go
@@ -143,7 +143,7 @@ func CachePage(store persistence.CacheStore, expire time.Duration, handle gin.Ha
 		url := c.Request.URL
 		key := urlEscape(PageCachePrefix, url.RequestURI())
 		if err := store.Get(key, &cache); err != nil {
-			log.Println(err.Error())
+			//log.Println(err.Error())
 			// replace writer
 			writer := newCachedWriter(store, expire, c.Writer, key)
 			c.Writer = writer


### PR DESCRIPTION
Maybe add a header for an X-Gin-Cache-Miss if it's a miss error?

It just produces unnessicairy spam in the log.

On second thought maybe only remove it if it's a miss error also..