### PR TITLE
Add persistence backend based on binary memcached client `mc`

### DIFF
--- a/persistence/cahe_store_test.go
+++ b/persistence/cahe_store_test.go
@@ -142,8 +142,8 @@ func testReplace(t *testing.T, newCache cacheFactory) {
 	cache := newCache(t, time.Hour)
 
 	// Replace in an empty cache.
-	if err = cache.Replace("notexist", 1, FOREVER); err != ErrNotStored {
-		t.Errorf("Replace in empty cache: expected ErrNotStored, got: %s", err)
+	if err = cache.Replace("notexist", 1, FOREVER); err != ErrNotStored && err != ErrCacheMiss {
+		t.Errorf("Replace in empty cache: expected ErrNotStored or ErrCacheMiss, got: %s", err)
 	}
 
 	// Set a value of 1, and replace it with 2
@@ -164,8 +164,8 @@ func testReplace(t *testing.T, newCache cacheFactory) {
 
 	// Wait for it to expire and replace with 3 (unsuccessfully).
 	time.Sleep(2 * time.Second)
-	if err = cache.Replace("int", 3, time.Second); err != ErrNotStored {
-		t.Errorf("Expected ErrNotStored, got: %s", err)
+	if err = cache.Replace("int", 3, time.Second); err != ErrNotStored && err != ErrCacheMiss {
+		t.Errorf("Expected ErrNotStored or ErrCacheMiss, got: %s", err)
 	}
 	if err = cache.Get("int", &i); err != ErrCacheMiss {
 		t.Errorf("Expected cache miss, got: %s", err)

--- a/persistence/memcached_binary.go
+++ b/persistence/memcached_binary.go
@@ -1,0 +1,115 @@
+package persistence
+
+import (
+	"time"
+
+	"github.com/memcachier/mc"
+	"github.com/gin-contrib/cache/utils"
+)
+
+// MemcachedBinaryStore represents the cache with memcached persistence using
+// the binary protocol
+type MemcachedBinaryStore struct {
+	*mc.Client
+	defaultExpiration time.Duration
+}
+
+// NewMemcachedBinaryStore returns a MemcachedBinaryStore
+func NewMemcachedBinaryStore(hostList, username, password string, defaultExpiration time.Duration) *MemcachedBinaryStore {
+	return &MemcachedBinaryStore{mc.NewMC(hostList, username, password), defaultExpiration}
+}
+
+// Set (see CacheStore interface)
+func (s *MemcachedBinaryStore) Set(key string, value interface{}, expires time.Duration) error {
+	exp := s.getExpiration(expires)
+	b, err := utils.Serialize(value)
+	if err != nil {
+		return err
+	}
+	_, err = s.Client.Set(key, string(b), 0, exp, 0)
+	return convertMcError(err)
+}
+
+// Add (see CacheStore interface)
+func (s *MemcachedBinaryStore) Add(key string, value interface{}, expires time.Duration) error {
+	exp := s.getExpiration(expires)
+	b, err := utils.Serialize(value)
+	if err != nil {
+		return err
+	}
+	_, err = s.Client.Add(key, string(b), 0, exp)
+	return convertMcError(err)
+}
+
+// Replace (see CacheStore interface)
+func (s *MemcachedBinaryStore) Replace(key string, value interface{}, expires time.Duration) error {
+	exp := s.getExpiration(expires)
+	b, err := utils.Serialize(value)
+	if err != nil {
+		return err
+	}
+	_, err = s.Client.Replace(key, string(b), 0, exp, 0)
+	return convertMcError(err)
+}
+
+// Get (see CacheStore interface)
+func (s *MemcachedBinaryStore) Get(key string, value interface{}) error {
+	val, _, _, err := s.Client.Get(key)
+	if err != nil {
+		return convertMcError(err)
+	}
+	return utils.Deserialize([]byte(val), value)
+}
+
+// Delete (see CacheStore interface)
+func (s *MemcachedBinaryStore) Delete(key string) error {
+	return convertMcError(s.Client.Del(key))
+}
+
+// Increment (see CacheStore interface)
+func (s *MemcachedBinaryStore) Increment(key string, delta uint64) (uint64, error) {
+	n, _, err := s.Client.Incr(key, delta, 0, 0xffffffff, 0)
+	return n, convertMcError(err)
+}
+
+// Decrement (see CacheStore interface)
+func (s *MemcachedBinaryStore) Decrement(key string, delta uint64) (uint64, error) {
+	n, _, err := s.Client.Decr(key, delta, 0, 0xffffffff, 0)
+	return n, convertMcError(err)
+}
+
+// Flush (see CacheStore interface)
+func (s *MemcachedBinaryStore) Flush() error {
+	return convertMcError(s.Client.Flush(0))
+}
+
+// getExpiration converts a gin-contrib/cache expiration in the form of a
+// time.Duration to a valid memcached expiration either in seconds (<30 days)
+// or a Unix timestamp (>30 days)
+func (s *MemcachedBinaryStore) getExpiration(expires time.Duration) uint32 {
+	switch expires {
+	case DEFAULT:
+		expires = s.defaultExpiration
+	case FOREVER:
+		expires = time.Duration(0)
+	}
+	exp := uint32(expires.Seconds())
+	if exp > 60*60*24*30 { // > 30 days
+		exp += uint32(time.Now().Unix())
+	}
+	return exp
+}
+
+func convertMcError(err error) error {
+	switch err {
+	case nil:
+		return nil
+	case mc.ErrNotFound:
+		return ErrCacheMiss
+	case mc.ErrValueNotStored:
+		return ErrNotStored
+	case mc.ErrKeyExists:
+		return ErrNotStored
+	}
+	return err
+}

--- a/persistence/memcached_binary.go
+++ b/persistence/memcached_binary.go
@@ -19,6 +19,11 @@ func NewMemcachedBinaryStore(hostList, username, password string, defaultExpirat
 	return &MemcachedBinaryStore{mc.NewMC(hostList, username, password), defaultExpiration}
 }
 
+// NewMemcachedBinaryStoreWithConfig returns a MemcachedBinaryStore using the provided configuration
+func NewMemcachedBinaryStoreWithConfig(hostList, username, password string, defaultExpiration time.Duration, config *mc.Config) *MemcachedBinaryStore {
+	return &MemcachedBinaryStore{mc.NewMCwithConfig(hostList, username, password, config), defaultExpiration}
+}
+
 // Set (see CacheStore interface)
 func (s *MemcachedBinaryStore) Set(key string, value interface{}, expires time.Duration) error {
 	exp := s.getExpiration(expires)

--- a/persistence/memcached_binary_test.go
+++ b/persistence/memcached_binary_test.go
@@ -1,0 +1,44 @@
+package persistence
+
+import (
+	"testing"
+	"time"
+)
+
+// These tests require memcached running on localhost:11211 (the default)
+const localhost = "localhost:11211"
+
+var newMcStore = func(t *testing.T, defaultExpiration time.Duration) CacheStore {
+	mcStore := NewMemcachedBinaryStore(localhost, "", "", defaultExpiration)
+	err := mcStore.Flush()
+	if err == nil {
+		return mcStore
+	}
+	t.Errorf("Failed to connect to memcached on %s with %s", localhost, err)
+	t.FailNow()
+	panic("")
+}
+
+func TestMemcachedBinary_TypicalGetSet(t *testing.T) {
+	typicalGetSet(t, newMcStore)
+}
+
+func TestMemcachedBinary_IncrDecr(t *testing.T) {
+	incrDecr(t, newMcStore)
+}
+
+func TestMemcachedBinary_Expiration(t *testing.T) {
+	expiration(t, newMcStore)
+}
+
+func TestMemcachedBinary_EmptyCache(t *testing.T) {
+	emptyCache(t, newMcStore)
+}
+
+func TestMemcachedBinary_Replace(t *testing.T) {
+	testReplace(t, newMcStore)
+}
+
+func TestMemcachedBinary_Add(t *testing.T) {
+	testAdd(t, newMcStore)
+}

--- a/persistence/memcached_binary_test.go
+++ b/persistence/memcached_binary_test.go
@@ -3,6 +3,8 @@ package persistence
 import (
 	"testing"
 	"time"
+
+	"github.com/memcachier/mc"
 )
 
 // These tests require memcached running on localhost:11211 (the default)
@@ -41,4 +43,41 @@ func TestMemcachedBinary_Replace(t *testing.T) {
 
 func TestMemcachedBinary_Add(t *testing.T) {
 	testAdd(t, newMcStore)
+}
+
+var newMcStoreWithConfig = func(t *testing.T, defaultExpiration time.Duration) CacheStore {
+	config := mc.DefaultConfig()
+	config.PoolSize = 2
+	mcStore := NewMemcachedBinaryStoreWithConfig(localhost, "", "", defaultExpiration, config)
+	err := mcStore.Flush()
+	if err == nil {
+		return mcStore
+	}
+	t.Errorf("Failed to connect to memcached on %s with %s", localhost, err)
+	t.FailNow()
+	panic("")
+}
+
+func TestMemcachedBinaryWithConfig_TypicalGetSet(t *testing.T) {
+	typicalGetSet(t, newMcStoreWithConfig)
+}
+
+func TestMemcachedBinaryWithConfig_IncrDecr(t *testing.T) {
+	incrDecr(t, newMcStoreWithConfig)
+}
+
+func TestMemcachedBinaryWithConfig_Expiration(t *testing.T) {
+	expiration(t, newMcStoreWithConfig)
+}
+
+func TestMemcachedBinaryWithConfig_EmptyCache(t *testing.T) {
+	emptyCache(t, newMcStoreWithConfig)
+}
+
+func TestMemcachedBinaryWithConfig_Replace(t *testing.T) {
+	testReplace(t, newMcStoreWithConfig)
+}
+
+func TestMemcachedBinaryWithConfig_Add(t *testing.T) {
+	testAdd(t, newMcStoreWithConfig)
 }


### PR DESCRIPTION
Fixes #27

This will allow the usage of a cloud memcached provider as a cache store.