### PR TITLE
Set headers instead of adding them

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -133,7 +133,7 @@ func SiteCache(store persistence.CacheStore, expire time.Duration) gin.HandlerFu
 			c.Writer.WriteHeader(cache.Status)
 			for k, vals := range cache.Header {
 				for _, v := range vals {
-					c.Writer.Header().Add(k, v)
+					c.Writer.Header().Set(k, v)
 				}
 			}
 			c.Writer.Write(cache.Data)
@@ -160,7 +160,7 @@ func CachePage(store persistence.CacheStore, expire time.Duration, handle gin.Ha
 			c.Writer.WriteHeader(cache.Status)
 			for k, vals := range cache.Header {
 				for _, v := range vals {
-					c.Writer.Header().Add(k, v)
+					c.Writer.Header().Set(k, v)
 				}
 			}
 			c.Writer.Write(cache.Data)


### PR DESCRIPTION
When using middleware that sets headers in addition to the cached page using `Header().Add()` will duplicate those headers. Instead we should overwrite them with `Header().Set()`, since we want to use the headers in the cache.

This resolvses #37.