### PR TITLE
Actually cache the status code

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -87,7 +87,7 @@ func (w *cachedWriter) Write(data []byte) (int, error) {
 
 		//cache response
 		val := responseCache{
-			w.status,
+			w.Status(),
 			w.Header(),
 			data,
 		}
@@ -105,7 +105,7 @@ func (w *cachedWriter) WriteString(data string) (n int, err error) {
 		//cache response
 		store := w.store
 		val := responseCache{
-			w.status,
+			w.Status(),
 			w.Header(),
 			[]byte(data),
 		}

--- a/cache_test.go
+++ b/cache_test.go
@@ -174,6 +174,23 @@ func TestCacheHtmlFileExpire(t *testing.T) {
 	assert.NotEqual(t, w1.Body.String(), w2.Body.String())
 }
 
+func TestCachePageStatus207(t *testing.T) {
+	store := persistence.NewInMemoryStore(60 * time.Second)
+
+	router := gin.New()
+	router.GET("/cache_207", CachePage(store, time.Second*3, func(c *gin.Context) {
+		c.String(207, fmt.Sprint(time.Now().UnixNano()))
+	}))
+
+	w1 := performRequest("GET", "/cache_207", router)
+	time.Sleep(time.Millisecond * 500)
+	w2 := performRequest("GET", "/cache_207", router)
+
+	assert.Equal(t, 207, w1.Code)
+	assert.Equal(t, 207, w2.Code)
+	assert.Equal(t, w1.Body.String(), w2.Body.String())
+}
+
 func performRequest(method, target string, router *gin.Engine) *httptest.ResponseRecorder {
 	r := httptest.NewRequest(method, target, nil)
 	w := httptest.NewRecorder()


### PR DESCRIPTION
Previously used `w.status` always returned 0, we need to use `w.Status()` to actually cache status codes.

This and pull request #39 resolves issue #35.