### PR TITLE
new func RegisterResponseCacheGob() …

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"sync"
 	"time"
+	"encoding/gob"
 
 	"github.com/gin-contrib/cache/persistence"
 	"github.com/gin-gonic/gin"
@@ -26,6 +27,10 @@ type responseCache struct {
 	Status int
 	Header http.Header
 	Data   []byte
+}
+// RegisterResponseCacheGob registers the responseCache type with the encoding/gob package
+func RegisterResponseCacheGob() {
+	gob.Register(responseCache{})
 }
 
 type cachedWriter struct {

--- a/cache_test.go
+++ b/cache_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+	"encoding/gob"
+	"bytes"
 
 	"github.com/gin-contrib/cache/persistence"
 	"github.com/gin-gonic/gin"
@@ -279,6 +281,21 @@ func TestCachePageWithoutQuery(t *testing.T) {
 	assert.Equal(t, w1.Body.String(), w2.Body.String())
 }
 
+func TestRegisterResponseCacheGob(t *testing.T) {
+	RegisterResponseCacheGob()
+	r := responseCache{Status:200, Data: []byte("test"),}
+	mCache := new(bytes.Buffer)
+	encCache := gob.NewEncoder(mCache)
+	err := encCache.Encode(r)
+	assert.Nil(t, err)
+	
+	var decodedResp responseCache
+	pCache := bytes.NewBuffer(mCache.Bytes())
+	decCache := gob.NewDecoder(pCache)
+	err = decCache.Decode(&decodedResp)
+	assert.Nil(t,err)
+
+}
 func performRequest(method, target string, router *gin.Engine) *httptest.ResponseRecorder {
 	r := httptest.NewRequest(method, target, nil)
 	w := httptest.NewRecorder()


### PR DESCRIPTION
so other contributors and implement caches that use gob encoding to serialize entries