### PR TITLE
add support for variations of redis atomic incrementing

### DIFF
--- a/persistence/redis.go
+++ b/persistence/redis.go
@@ -186,6 +186,21 @@ func (c *RedisStore) IncrementAtomic(key string, delta uint64) (uint64, error) {
 	return uint64(newValue.(int64)), nil
 }
 
+// ExpireAt - special case for Redis storage to handle updating the TTL for the entry for when
+// a consumer wants to use this storage for something outside the standard cache contract.
+func (c *RedisStore) ExpireAt(key string, epoc uint64) error {
+	conn := c.pool.Get()
+	defer conn.Close()
+	ret, err := conn.Do("EXPIREAT", key, epoc)
+	if ret == 0 {
+		return ErrCacheMiss
+	}
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // Decrement (see CacheStore interface)
 func (c *RedisStore) Decrement(key string, delta uint64) (newValue uint64, err error) {
 	conn := c.pool.Get()

--- a/persistence/redis.go
+++ b/persistence/redis.go
@@ -148,6 +148,44 @@ func (c *RedisStore) Increment(key string, delta uint64) (uint64, error) {
 	return 0, err
 }
 
+// IncrementCheckSet - special case where you want to increment a value ONLY if it doesn't change between your GET and SET
+func (c *RedisStore) IncrementCheckSet(key string, delta uint64) (uint64, error) {
+	conn := c.pool.Get()
+	defer conn.Close()
+	conn.Do("WATCH", key)
+	defer conn.Do("UNWATCH", key)
+	val, err := conn.Do("GET", key)
+	if val == nil {
+		return 0, ErrCacheMiss
+	}
+	if err == nil {
+		currentVal, err := redis.Int64(val, nil)
+		if err != nil {
+			return 0, err
+		}
+		sum := currentVal + int64(delta)
+		_, err = conn.Do("SET", key, sum)
+		if err != nil {
+			return 0, err
+		}
+		return uint64(sum), nil
+	}
+	return 0, err
+}
+
+// IncrementAtomic - special case for Redis storage to handle the need for atomic increments without a data race problem when
+// a consumer wants to use this storage for something outside the standard cache contract.
+func (c *RedisStore) IncrementAtomic(key string, delta uint64) (uint64, error) {
+	conn := c.pool.Get()
+	defer conn.Close()
+
+	newValue, err := conn.Do("INCRBY", key, delta)
+	if err != nil {
+		return 0, err
+	}
+	return uint64(newValue.(int64)), nil
+}
+
 // Decrement (see CacheStore interface)
 func (c *RedisStore) Decrement(key string, delta uint64) (newValue uint64, err error) {
 	conn := c.pool.Get()

--- a/persistence/redis_incr_atomic_test.go
+++ b/persistence/redis_incr_atomic_test.go
@@ -1,0 +1,61 @@
+package persistence
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+type redisStoreFactory func(*testing.T, time.Duration) *RedisStore
+
+var newRawRedisStore = func(t *testing.T, defaultExpiration time.Duration) *RedisStore {
+	c, err := net.Dial("tcp", redisTestServer)
+	if err == nil {
+		c.Write([]byte("flush_all\r\n"))
+		c.Close()
+		redisCache := NewRedisCache(redisTestServer, "", defaultExpiration)
+		redisCache.Flush()
+		return redisCache
+	}
+	t.Errorf("couldn't connect to redis on %s", redisTestServer)
+	t.FailNow()
+	panic("")
+}
+
+// Test the increment-decrement cases
+func incrAtomic(t *testing.T, newStore redisStoreFactory) {
+	var err error
+	store := newStore(t, time.Hour)
+
+	// Normal increment / decrement operation.
+	if err = store.Set("int", 10, DEFAULT); err != nil {
+		t.Errorf("Error setting int: %s", err)
+	}
+
+	newValue, err := store.IncrementCheckSet("int", 50)
+	if err != nil {
+		t.Errorf("Error incrementing int: %s", err)
+	}
+	if newValue != 60 {
+		t.Errorf("Expected 60, was %d", newValue)
+	}
+	newValue, err = store.IncrementCheckSet("int", 50)
+	if err != nil {
+		t.Errorf("Error incrementing int: %s", err)
+	}
+	if newValue != 110 {
+		t.Errorf("Expected 110, was %d", newValue)
+	}
+	newValue, err = store.IncrementCheckSet("badkey", 50)
+	if err != ErrCacheMiss {
+		t.Errorf("Error incrementing badkey.. should have been ErrCacheMiss")
+	}
+	newValue, err = store.IncrementAtomic("newInt", 2)
+	if err != nil {
+		t.Errorf("Error incrementing int: %s", err)
+	}
+	if newValue != 2 {
+		t.Errorf("Expected 2, was %d", newValue)
+	}
+
+}

--- a/persistence/redis_incr_atomic_test.go
+++ b/persistence/redis_incr_atomic_test.go
@@ -58,4 +58,23 @@ func incrAtomic(t *testing.T, newStore redisStoreFactory) {
 		t.Errorf("Expected 2, was %d", newValue)
 	}
 
+	err = store.ExpireAt("int", uint64(time.Now().Unix()+10))
+	if err != nil {
+		t.Errorf("Error setting expire at: %s", err.Error())
+	}
+	var value int
+	err = store.Get("int", &value)
+	if newValue != 2 {
+		t.Errorf("Expected 2, was %d", newValue)
+	}
+	err = store.ExpireAt("int", uint64(time.Now().Unix()+1))
+	time.Sleep(2 * time.Second)
+	err = store.Get("int", &value)
+	if newValue != 2 {
+		t.Errorf("Expected 2, was %d", newValue)
+	}
+	if err != ErrCacheMiss {
+		t.Errorf("Expected to NOT get the value, but got: %v", value)
+	}
+
 }

--- a/persistence/redis_test.go
+++ b/persistence/redis_test.go
@@ -30,6 +30,9 @@ func TestRedisCache_TypicalGetSet(t *testing.T) {
 func TestRedisCache_IncrDecr(t *testing.T) {
 	incrDecr(t, newRedisStore)
 }
+func TestRedis_IncrAtomic(t *testing.T) {
+	incrAtomic(t, newRawRedisStore)
+}
 
 func TestRedisCache_Expiration(t *testing.T) {
 	expiration(t, newRedisStore)


### PR DESCRIPTION
Current Redis implementation has a data race.  It would be great to support more atomic incrementing for the Redis store.  It's not in the contract of the current page cache but makes the library more usable for general caching.