### PR TITLE
Introduce `func NewCacheStore(opts Options) (CacheStore, error)` and a method `New(opts Options) CacheStore` to the `CacheStore` interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 coverage.out
 dump.rdb
+
+.idea/
+vendor/

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ See the [example](example/example.go)
 package main
 
 import (
-	"fmt"
+	"log"
+	"net/http"
 	"time"
 
 	"github.com/gin-contrib/cache"
@@ -42,17 +43,57 @@ import (
 func main() {
 	r := gin.Default()
 
-	store := persistence.NewInMemoryStore(time.Second)
-	
-	r.GET("/ping", func(c *gin.Context) {
-		c.String(200, "pong "+fmt.Sprint(time.Now().Unix()))
+	opts := persistence.Options{
+		Adapter:           persistence.AdapterInMemoryStore,
+		DefaultExpiration: 60 * time.Second,
+	}
+	store, err := persistence.NewCacheStore(opts)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	// Use cache.Cache middleware
+	r.Use(cache.Cache(store))
+
+	ping := "ping"
+
+	// Store data to cache store
+	r.GET("/cache_set", func(ctx *gin.Context) {
+		store, exist := ctx.Get(cache.CACHE_MIDDLEWARE_KEY)
+		if !exist {
+			ctx.String(http.StatusInternalServerError, "cache middleware not found")
+			return
+		}
+
+		cacheStore := store.(persistence.CacheStore)
+		if err := cacheStore.Set(ping, "pong", time.Minute); err != nil {
+			ctx.String(http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		ctx.String(http.StatusOK, "value set to cache `%s: pong`\n", ping)
 	})
-	// Cached Page
-	r.GET("/cache_ping", cache.CachePage(store, time.Minute, func(c *gin.Context) {
-		c.String(200, "pong "+fmt.Sprint(time.Now().Unix()))
-	}))
+
+	// Read data from cache store
+	r.GET("/cache_get", func(ctx *gin.Context) {
+		store, exist := ctx.Get(cache.CACHE_MIDDLEWARE_KEY)
+		if !exist {
+			ctx.String(http.StatusInternalServerError, "cache middleware not found")
+			return
+		}
+		cacheStore := store.(persistence.CacheStore)
+
+		var value string
+		if err := cacheStore.Get(ping, &value); err != nil {
+			ctx.String(http.StatusNotFound, err.Error())
+			return
+		}
+		ctx.String(http.StatusOK, "value read from cache `%s: %s`\n", ping, value)
+	})
 
 	// Listen and Server in 0.0.0.0:8080
-	r.Run(":8080")
+	if err := r.Run(":8080"); err != nil {
+		log.Fatal(err)
+	}
 }
 ```

--- a/cache.go
+++ b/cache.go
@@ -3,13 +3,13 @@ package cache
 import (
 	"bytes"
 	"crypto/sha1"
+	"encoding/gob"
 	"io"
 	"log"
 	"net/http"
 	"net/url"
 	"sync"
 	"time"
-	"encoding/gob"
 
 	"github.com/gin-contrib/cache/persistence"
 	"github.com/gin-gonic/gin"
@@ -28,6 +28,7 @@ type responseCache struct {
 	Header http.Header
 	Data   []byte
 }
+
 // RegisterResponseCacheGob registers the responseCache type with the encoding/gob package
 func RegisterResponseCacheGob() {
 	gob.Register(responseCache{})
@@ -122,7 +123,7 @@ func (w *cachedWriter) WriteString(data string) (n int, err error) {
 }
 
 // Cache Middleware
-func Cache(store *persistence.CacheStore) gin.HandlerFunc {
+func Cache(store persistence.CacheStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.Set(CACHE_MIDDLEWARE_KEY, store)
 		c.Next()

--- a/example/example.go
+++ b/example/example.go
@@ -1,7 +1,8 @@
 package main
 
 import (
-	"fmt"
+	"log"
+	"net/http"
 	"time"
 
 	"github.com/gin-contrib/cache"
@@ -12,16 +13,56 @@ import (
 func main() {
 	r := gin.Default()
 
-	store := persistence.NewInMemoryStore(60 * time.Second)
-	// Cached Page
-	r.GET("/ping", func(c *gin.Context) {
-		c.String(200, "pong "+fmt.Sprint(time.Now().Unix()))
+	opts := persistence.Options{
+		Adapter:           persistence.AdapterInMemoryStore,
+		DefaultExpiration: 60 * time.Second,
+	}
+	store, err := persistence.NewCacheStore(opts)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	// Use cache.Cache middleware
+	r.Use(cache.Cache(store))
+
+	ping := "ping"
+
+	// Store data to cache store
+	r.GET("/cache_set", func(ctx *gin.Context) {
+		store, exist := ctx.Get(cache.CACHE_MIDDLEWARE_KEY)
+		if !exist {
+			ctx.String(http.StatusInternalServerError, "cache middleware not found")
+			return
+		}
+
+		cacheStore := store.(persistence.CacheStore)
+		if err := cacheStore.Set(ping, "pong", time.Minute); err != nil {
+			ctx.String(http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		ctx.String(http.StatusOK, "value set to cache `%s: pong`\n", ping)
 	})
 
-	r.GET("/cache_ping", cache.CachePage(store, time.Minute, func(c *gin.Context) {
-		c.String(200, "pong "+fmt.Sprint(time.Now().Unix()))
-	}))
+	// Read data from cache store
+	r.GET("/cache_get", func(ctx *gin.Context) {
+		store, exist := ctx.Get(cache.CACHE_MIDDLEWARE_KEY)
+		if !exist {
+			ctx.String(http.StatusInternalServerError, "cache middleware not found")
+			return
+		}
+		cacheStore := store.(persistence.CacheStore)
+
+		var value string
+		if err := cacheStore.Get(ping, &value); err != nil {
+			ctx.String(http.StatusNotFound, err.Error())
+			return
+		}
+		ctx.String(http.StatusOK, "value read from cache `%s: %s`\n", ping, value)
+	})
 
 	// Listen and Server in 0.0.0.0:8080
-	r.Run(":8080")
+	if err := r.Run(":8080"); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/gin-contrib/cache
 
+go 1.13
+
 require (
 	github.com/bradfitz/gomemcache v0.0.0-20190329173943-551aad21a668
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/persistence/inmemory.go
+++ b/persistence/inmemory.go
@@ -12,9 +12,9 @@ type InMemoryStore struct {
 	cache.Cache
 }
 
-// NewInMemoryStore returns a InMemoryStore
-func NewInMemoryStore(defaultExpiration time.Duration) *InMemoryStore {
-	return &InMemoryStore{*cache.New(defaultExpiration, time.Minute)}
+// New returns a InMemoryStore type CacheStore associated with the provided expiration
+func (c *InMemoryStore) New(opts Options) CacheStore {
+	return &InMemoryStore{*cache.New(opts.DefaultExpiration, time.Minute)}
 }
 
 // Get (see CacheStore interface)
@@ -86,4 +86,8 @@ func (c *InMemoryStore) Decrement(key string, n uint64) (uint64, error) {
 func (c *InMemoryStore) Flush() error {
 	c.Cache.Flush()
 	return nil
+}
+
+func init() {
+	Register(AdapterInMemoryStore, &InMemoryStore{})
 }

--- a/persistence/inmemory_test.go
+++ b/persistence/inmemory_test.go
@@ -3,10 +3,18 @@ package persistence
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
-var newInMemoryStore = func(_ *testing.T, defaultExpiration time.Duration) CacheStore {
-	return NewInMemoryStore(defaultExpiration)
+var newInMemoryStore = func(t *testing.T, defaultExpiration time.Duration) CacheStore {
+	opts := Options{
+		Adapter:           AdapterInMemoryStore,
+		DefaultExpiration: defaultExpiration,
+	}
+	inMemoryStore, err := NewCacheStore(opts)
+	assert.NoError(t, err)
+	return inMemoryStore
 }
 
 // Test typical cache interactions

--- a/persistence/memcached.go
+++ b/persistence/memcached.go
@@ -13,9 +13,14 @@ type MemcachedStore struct {
 	defaultExpiration time.Duration
 }
 
-// NewMemcachedStore returns a MemcachedStore
-func NewMemcachedStore(hostList []string, defaultExpiration time.Duration) *MemcachedStore {
-	return &MemcachedStore{memcache.New(hostList...), defaultExpiration}
+// MemCachedConfig contains configuration for MemcachedStore
+type MemCachedConfig struct {
+	HostList []string
+}
+
+// New returns a MemcachedStore type CacheStore associated with the provided configuration
+func (c *MemcachedStore) New(opts Options) CacheStore {
+	return &MemcachedStore{memcache.New(opts.MemCachedConfig.HostList...), opts.DefaultExpiration}
 }
 
 // Set (see CacheStore interface)
@@ -96,4 +101,8 @@ func convertMemcacheError(err error) error {
 	}
 
 	return err
+}
+
+func init() {
+	Register(AdapterMemcachedStore, &MemcachedStore{})
 }

--- a/persistence/memcached_binary_test.go
+++ b/persistence/memcached_binary_test.go
@@ -5,14 +5,27 @@ import (
 	"time"
 
 	"github.com/memcachier/mc"
+	"github.com/stretchr/testify/assert"
 )
 
 // These tests require memcached running on localhost:11211 (the default)
 const localhost = "localhost:11211"
 
 var newMcStore = func(t *testing.T, defaultExpiration time.Duration) CacheStore {
-	mcStore := NewMemcachedBinaryStore(localhost, "", "", defaultExpiration)
-	err := mcStore.Flush()
+	opts := Options{
+		Adapter: AdapterMemcachedBinaryStore,
+		AdapterConfig: AdapterConfig{
+			MemcachedBinaryConfig: &MemcachedBinaryConfig{
+				HostList: localhost,
+				Username: "",
+				Password: "",
+			},
+		},
+		DefaultExpiration: defaultExpiration,
+	}
+	mcStore, err := NewCacheStore(opts)
+	assert.NoError(t, err)
+	err = mcStore.Flush()
 	if err == nil {
 		return mcStore
 	}
@@ -48,8 +61,21 @@ func TestMemcachedBinary_Add(t *testing.T) {
 var newMcStoreWithConfig = func(t *testing.T, defaultExpiration time.Duration) CacheStore {
 	config := mc.DefaultConfig()
 	config.PoolSize = 2
-	mcStore := NewMemcachedBinaryStoreWithConfig(localhost, "", "", defaultExpiration, config)
-	err := mcStore.Flush()
+	opts := Options{
+		Adapter: AdapterMemcachedBinaryStore,
+		AdapterConfig: AdapterConfig{
+			MemcachedBinaryConfig: &MemcachedBinaryConfig{
+				HostList: localhost,
+				Username: "",
+				Password: "",
+				McConfig: config,
+			},
+		},
+		DefaultExpiration: defaultExpiration,
+	}
+	mcStore, err := NewCacheStore(opts)
+	assert.NoError(t, err)
+	err = mcStore.Flush()
 	if err == nil {
 		return mcStore
 	}

--- a/persistence/memcached_test.go
+++ b/persistence/memcached_test.go
@@ -4,6 +4,8 @@ import (
 	"net"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // These tests require memcached running on localhost:11211 (the default)
@@ -14,7 +16,18 @@ var newMemcachedStore = func(t *testing.T, defaultExpiration time.Duration) Cach
 	if err == nil {
 		c.Write([]byte("flush_all\r\n"))
 		c.Close()
-		return NewMemcachedStore([]string{testServer}, defaultExpiration)
+		opts := Options{
+			Adapter: AdapterMemcachedStore,
+			AdapterConfig: AdapterConfig{
+				MemCachedConfig: &MemCachedConfig{
+					HostList: []string{testServer},
+				},
+			},
+			DefaultExpiration: defaultExpiration,
+		}
+		mcStore, err := NewCacheStore(opts)
+		assert.NoError(t, err)
+		return mcStore
 	}
 	t.Errorf("couldn't connect to memcached on %s", testServer)
 	t.FailNow()

--- a/persistence/redis_test.go
+++ b/persistence/redis_test.go
@@ -4,6 +4,8 @@ import (
 	"net"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // These tests require redis server running on localhost:6379 (the default)
@@ -14,9 +16,20 @@ var newRedisStore = func(t *testing.T, defaultExpiration time.Duration) CacheSto
 	if err == nil {
 		c.Write([]byte("flush_all\r\n"))
 		c.Close()
-		redisCache := NewRedisCache(redisTestServer, "", defaultExpiration)
-		redisCache.Flush()
-		return redisCache
+		opts := Options{
+			Adapter: AdapterRedisStore,
+			AdapterConfig: AdapterConfig{
+				RedisConfig: &RedisConfig{
+					Host:     redisTestServer,
+					Password: "",
+				},
+			},
+			DefaultExpiration: defaultExpiration,
+		}
+		redisStore, err := NewCacheStore(opts)
+		assert.NoError(t, err)
+		redisStore.Flush()
+		return redisStore
 	}
 	t.Errorf("couldn't connect to redis on %s", redisTestServer)
 	t.FailNow()


### PR DESCRIPTION
## What changes are made ?

I introduced a new method `New(opts Options) CacheStore` to the `CacheStore` interface and implemented the `New() method` in every `CacheStore` available here.

- Removed `NewInMemoryStore`, `NewMemcachedStore`, `NewMemcachedBinaryStore`, `NewMemcachedBinaryStoreWithConfig`, `NewRedisCache` & `NewRedisCacheWithPool` functions. 
- Introduced `func NewCacheStore(opts Options) (CacheStore, error)` which internally uses the `New(opts Options) CacheStore` method.
- Removed pointer from `persistence.CacheStore` in  middleware `func Cache(store *persistence.CacheStore) gin.HandlerFunc` & wrote a test for this, which seems to be working fine.
- Updated every tests where the current changes make impact.
- Updated `example/example.go` and `README.md` focusing on how to use the current changes.

## Why the changes are made ?

**func NewCacheStore(opts Options) (CacheStore, error)**

There was no general way of getting a `CacheStore`. If they wanted to use `InMemoryStore`, they had to call `NewInMemoryStore` function. for `RedisStore` they had to call `NewRedisCache`.

Besides, by calling `NewRedisCache`, we get `RedisStore` not `persistence.CacheStore`.
If we wanted to get the `RedisStore` as `persistence.CacheStore`, we had to do the following:
```go
var store persistence.CacheStore
store = persistence.NewRedisStore(...)
```
I wanted to make it more general. So, I implemented a function `NewCacheStore(opts Options) (CacheStore, error)`. Now users can call this function no matter whichever cache store they need, they just need to define configs in `opts` struct according to the expected cache store.



**func Cache(store persistence.CacheStore) gin.HandlerFunc**

I think we don't need to use pointer for an interface. We can just pass the `CacheStore` to the middleware as the underlying every CacheStore we get from `NewCacheStore(opts Options) (CacheStore, error)` is actually pointer

Also I completed the `func TestCache(t *testing.T)`.

## Where and how do these changes affect ?

I added `func Register(name string, adapter CacheStore)`, so in future if anyone wants to add a new/custom cache store they will need to register their cache store using this `Register` function.

Users who were using `NewInMemoryStore`, `NewMemcachedStore`, `NewMemcachedBinaryStore`, `NewMemcachedBinaryStoreWithConfig`, `NewRedisCache` or `NewRedisCacheWithPool` functions, will need to replace those with the following:
```go
opts := Options{
	Adapter: AdapterRedisStore,
	AdapterConfig: AdapterConfig{
		RedisConfig: &RedisConfig{...},
	},
	DefaultExpiration: defaultExpiration,
}
store, err := persistence.NewCacheStore(opts)
```
This will provide a `RedisStore` type `CacheStore`
