### PR TITLE
wrong cached result when a cached file's size is more than 32768

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -86,8 +86,12 @@ func (w *cachedWriter) Write(data []byte) (int, error) {
 	if err == nil {
 		store := w.store
 		var cache responseCache
+
 		if err := store.Get(w.key, &cache); err == nil {
-			data = append(cache.Data, data...)
+			cache.Data = append(cache.Data, data...)
+		}else{
+			cache.Data = make([]byte,0)
+			cache.Data = append(cache.Data, data...)
 		}
 
 		//cache responses with a status code < 300
@@ -95,7 +99,7 @@ func (w *cachedWriter) Write(data []byte) (int, error) {
 			val := responseCache{
 				w.Status(),
 				w.Header(),
-				data,
+				cache.Data,
 			}
 			err = store.Set(w.key, val, w.expire)
 			if err != nil {


### PR DESCRIPTION
the append result "data" is now using the same as param input "data".
when a cached file which size is more than 32768 there are more than one Write()  invoked
the cached "data" will be changed when next Write() arrived,as []byte in golang is a ref type  


![image](https://user-images.githubusercontent.com/20122014/78746411-5d454780-7999-11ea-90a0-d375aa471ed4.png)
