### PR TITLE
MemoryLeak, should pass point for cache.Cache

### DIFF
--- a/persistence/inmemory.go
+++ b/persistence/inmemory.go
@@ -9,12 +9,12 @@ import (
 
 //InMemoryStore represents the cache with memory persistence
 type InMemoryStore struct {
-	cache.Cache
+	*cache.Cache
 }
 
 // NewInMemoryStore returns a InMemoryStore
 func NewInMemoryStore(defaultExpiration time.Duration) *InMemoryStore {
-	return &InMemoryStore{*cache.New(defaultExpiration, time.Minute)}
+	return &InMemoryStore{cache.New(defaultExpiration, time.Minute)}
 }
 
 // Get (see CacheStore interface)


### PR DESCRIPTION
When the cache is created, a finalizer will stop ticking if no reference to the pointer

func New(defaultExpiration, cleanupInterval time.Duration) *Cache {
	c := newCache(defaultExpiration)
	// This trick ensures that the janitor goroutine (which--granted it
	// was enabled--is running DeleteExpired on c forever) does not keep
	// the returned C object from being garbage collected. When it is
	// garbage collected, the finalizer stops the janitor goroutine, after
	// which c can be collected.
	C := &Cache{c}
	if cleanupInterval > 0 {
		runJanitor(c, cleanupInterval)
		runtime.SetFinalizer(C, stopJanitor)
	}
	return C
}

if InMemoryStore is using value assignment, the point may change which will cause finalizer be triggered and stopped ticking
&InMemoryStore{cache.New(defaultExpiration, time.Minute)}

Therefore should use pointer here.