### PR TITLE
remove append on existing cache

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -86,10 +86,6 @@ func (w *cachedWriter) Write(data []byte) (int, error) {
 	ret, err := w.ResponseWriter.Write(data)
 	if err == nil {
 		store := w.store
-		var cache responseCache
-		if err := store.Get(w.key, &cache); err == nil {
-			data = append(cache.Data, data...)
-		}
 
 		//cache responses with a status code < 300
 		if w.Status() < 300 {


### PR DESCRIPTION
Related with #15 

CachePageAtomic was introduced to atomically cache a page and avoid duplication, however if you are running in multiple instances this will still occur.

Looking into the code I notice that when writing a cache if the key already contains data we are appending it, however this should not happen (in my opinion), if we are setting a cache we should overwrite the existing contents.