### PR TITLE
perf: optimize cache key generation with xxhash and benchmarking

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           go test -v ./persistence
           go test -v -covermode=atomic -coverprofile=coverage.out .
+          go test -bench=. -benchmem -run=^$ ./...
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/cache_benchmark_test.go
+++ b/cache_benchmark_test.go
@@ -1,0 +1,66 @@
+package cache
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"fmt"
+	"io"
+	"net/url"
+	"testing"
+)
+
+func BenchmarkGenerateCacheKey_Short(b *testing.B) {
+	b.ResetTimer()
+	b.ReportAllocs()
+	key := "/api/v1/resource?id=123"
+	for i := 0; i < b.N; i++ {
+		_ = generateCacheKey("prefix", key)
+	}
+}
+
+func BenchmarkGenerateCacheKey_Long(b *testing.B) {
+	b.ResetTimer()
+	b.ReportAllocs()
+	longKey := "/api/v1/resource?" + generateLongQuery(1000)
+	for i := 0; i < b.N; i++ {
+		_ = generateCacheKey("prefix", longKey)
+	}
+}
+
+func generateLongQuery(n int) string {
+	s := ""
+	for i := 0; i < n; i++ {
+		s += fmt.Sprintf("k%d=v%d&", i, i)
+	}
+	return s
+}
+
+func BenchmarkGenerateURLEscapeKey_Short(b *testing.B) {
+	b.ResetTimer()
+	b.ReportAllocs()
+	key := "/api/v1/resource?id=123"
+	for i := 0; i < b.N; i++ {
+		_ = urlEscape("prefix", key)
+	}
+}
+
+func BenchmarkGenerateURLEscapeKey_Long(b *testing.B) {
+	b.ResetTimer()
+	b.ReportAllocs()
+	longKey := "/api/v1/resource?" + generateLongQuery(1000)
+	for i := 0; i < b.N; i++ {
+		_ = urlEscape("prefix", longKey)
+	}
+}
+
+func urlEscape(prefix string, u string) string {
+	key := url.QueryEscape(u)
+	h := sha1.New()
+	_, _ = io.WriteString(h, u)
+	key = string(h.Sum(nil))
+	var buffer bytes.Buffer
+	buffer.WriteString(prefix)
+	buffer.WriteString(":")
+	buffer.WriteString(key)
+	return buffer.String()
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.0
 
 require (
 	github.com/bradfitz/gomemcache v0.0.0-20250403215159-8d39553ac7cf
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/gin-gonic/gin v1.10.1
 	github.com/gomodule/redigo v1.9.2
 	github.com/memcachier/mc/v3 v3.0.3

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/bytedance/sonic v1.13.2/go.mod h1:o68xyaF9u2gvVBuGHPlUVCy+ZfmNNO5ETf1
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
 github.com/bytedance/sonic/loader v0.2.4 h1:ZWCw4stuXUsn1/+zQDqeE7JKP+QO47tz7QCNan80NzY=
 github.com/bytedance/sonic/loader v0.2.4/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFosQU6FxH2JmUe6VI=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudwego/base64x v0.1.5 h1:XPciSp1xaq2VCSt6lF0phncD4koWyULpl5bUxbfCyP4=
 github.com/cloudwego/base64x v0.1.5/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJgA0rcu/8w=
 github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQPiEFhY=


### PR DESCRIPTION
- Add go test benchmarking step to GitHub Actions workflow
- Replace SHA1 and URL-escaping in cache key generation with xxhash for improved performance
- Refactor cache key generation to use sync.Pool for hasher and builder reuse
- Add a new cache_benchmark_test.go file benchmarking both the old and new cache key mechanisms
- Add github.com/cespare/xxhash/v2 as a new dependency in go.mod