### PR TITLE
feat: refactor and unify Redis connection and testing logic

### DIFF
--- a/persistence/redis_test.go
+++ b/persistence/redis_test.go
@@ -7,46 +7,54 @@ import (
 )
 
 // These tests require redis server running on localhost:6379 (the default)
-const redisTestServer = "localhost:6379"
+const (
+	redisTestServer = "localhost:6379"
+	redisTestURL    = "redis://localhost:6379"
+)
 
-var newRedisStore = func(t *testing.T, defaultExpiration time.Duration) CacheStore {
+func newRedisStore(t *testing.T, defaultExpiration time.Duration) CacheStore {
 	c, err := net.Dial("tcp", redisTestServer)
-	if err == nil {
-		_, _ = c.Write([]byte("flush_all\r\n"))
-		if err := c.Close(); err != nil {
-			t.Errorf("Error closing connection: %v", err)
-		}
-		redisCache := NewRedisCache(redisTestServer, "", defaultExpiration)
-		if err := redisCache.Flush(); err != nil {
-			t.Errorf("Error flushing cache: %v", err)
-		}
-		return redisCache
+	if err != nil {
+		t.Errorf("couldn't connect to redis on %s", redisTestServer)
+		t.FailNow()
 	}
-	t.Errorf("couldn't connect to redis on %s", redisTestServer)
-	t.FailNow()
-	panic("")
+	_, _ = c.Write([]byte("flush_all\r\n"))
+	if err := c.Close(); err != nil {
+		t.Errorf("Error closing connection: %v", err)
+	}
+	redisCache := NewRedisCache(redisTestServer, "", defaultExpiration)
+	if err := redisCache.Flush(); err != nil {
+		t.Errorf("Error flushing cache: %v", err)
+	}
+	return redisCache
 }
 
-func TestRedisCache_TypicalGetSet(t *testing.T) {
-	typicalGetSet(t, newRedisStore)
+func newRedisStoreWithURL(t *testing.T, defaultExpiration time.Duration) CacheStore {
+	c, err := net.Dial("tcp", redisTestServer)
+	if err != nil {
+		t.Skipf("couldn't connect to redis on %s, skipping URL-based tests", redisTestServer)
+	}
+	_, _ = c.Write([]byte("flush_all\r\n"))
+	if err := c.Close(); err != nil {
+		t.Errorf("Error closing connection: %v", err)
+	}
+	redisCache := NewRedisCacheWithURL(redisTestURL, defaultExpiration)
+	if err := redisCache.Flush(); err != nil {
+		t.Errorf("Error flushing cache: %v", err)
+	}
+	return redisCache
 }
 
-func TestRedisCache_IncrDecr(t *testing.T) {
-	incrDecr(t, newRedisStore)
+func runCommonTests(t *testing.T, factory cacheFactory) {
+	t.Run("TypicalGetSet", func(t *testing.T) { typicalGetSet(t, factory) })
+	t.Run("IncrDecr", func(t *testing.T) { incrDecr(t, factory) })
+	t.Run("Expiration", func(t *testing.T) { expiration(t, factory) })
+	t.Run("EmptyCache", func(t *testing.T) { emptyCache(t, factory) })
+	t.Run("Replace", func(t *testing.T) { testReplace(t, factory) })
+	t.Run("Add", func(t *testing.T) { testAdd(t, factory) })
 }
 
-func TestRedisCache_Expiration(t *testing.T) {
-	expiration(t, newRedisStore)
-}
-
-func TestRedisCache_EmptyCache(t *testing.T) {
-	emptyCache(t, newRedisStore)
-}
-
-func TestRedisCache_Replace(t *testing.T) {
-	testReplace(t, newRedisStore)
-}
-
-func TestRedisCache_Add(t *testing.T) {
-	testAdd(t, newRedisStore)
+func TestRedisCache(t *testing.T) {
+	t.Run("Standard", func(t *testing.T) { runCommonTests(t, newRedisStore) })
+	t.Run("WithURL", func(t *testing.T) { runCommonTests(t, newRedisStoreWithURL) })
 }


### PR DESCRIPTION
- Add a function to create a Redis cache from a URL using redis.DialURL
- Refactor redis test helpers for better error handling and to support both standard and URL-based Redis connections
- Consolidate and organize Redis tests to run under standard and URL-based configurations

fix https://github.com/gin-contrib/cache/issues/105