### PR TITLE
docs: correct example link to reference proper directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ import "github.com/gin-contrib/cache"
 
 ### InMemory Example
 
-See the [example](example/example.go)
+See the [example](_example/example.go)
 
 ```go
 package main


### PR DESCRIPTION
- Update the example link to reference the correct _example directory

fix https://github.com/gin-contrib/cache/issues/113