### PR TITLE
fix: restore cached headers before writing status

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -203,12 +203,12 @@ func SiteCache(store persistence.CacheStore, expire time.Duration) gin.HandlerFu
 		if err := store.Get(key, &cache); err != nil {
 			c.Next()
 		} else {
-			c.Writer.WriteHeader(cache.Status)
 			for k, vals := range cache.Header {
 				for _, v := range vals {
 					c.Writer.Header().Set(k, v)
 				}
 			}
+			c.Writer.WriteHeader(cache.Status)
 			_, _ = c.Writer.Write(cache.Data)
 		}
 	}
@@ -236,12 +236,12 @@ func CachePage(store persistence.CacheStore, expire time.Duration, handle gin.Ha
 				_ = store.Delete(key)
 			}
 		} else {
-			c.Writer.WriteHeader(cache.Status)
 			for k, vals := range cache.Header {
 				for _, v := range vals {
 					c.Writer.Header().Set(k, v)
 				}
 			}
+			c.Writer.WriteHeader(cache.Status)
 			_, _ = c.Writer.Write(cache.Data)
 		}
 	}
@@ -262,12 +262,12 @@ func CachePageWithoutQuery(store persistence.CacheStore, expire time.Duration, h
 			c.Writer = writer
 			handle(c)
 		} else {
-			c.Writer.WriteHeader(cache.Status)
 			for k, vals := range cache.Header {
 				for _, v := range vals {
 					c.Writer.Header().Set(k, v)
 				}
 			}
+			c.Writer.WriteHeader(cache.Status)
 			_, _ = c.Writer.Write(cache.Data)
 		}
 	}

--- a/cache_test.go
+++ b/cache_test.go
@@ -54,6 +54,22 @@ func TestCachePage(t *testing.T) {
 	assert.Equal(t, w1.Body.String(), w2.Body.String())
 }
 
+func TestCachePageRestoresHeadersBeforeWritingStatus(t *testing.T) {
+	store := persistence.NewInMemoryStore(60 * time.Second)
+
+	router := gin.New()
+	router.GET("/cache_headers", CachePage(store, time.Second*3, func(c *gin.Context) {
+		c.Header("X-Cache-Test", "present")
+		c.String(http.StatusCreated, "cached")
+	}))
+
+	_ = performRequest("GET", "/cache_headers", router)
+	cached := performRequest("GET", "/cache_headers", router)
+
+	assert.Equal(t, http.StatusCreated, cached.Code)
+	assert.Equal(t, "present", cached.Result().Header.Get("X-Cache-Test"))
+}
+
 func TestCachePageExpire(t *testing.T) {
 	store := persistence.NewInMemoryStore(60 * time.Second)
 


### PR DESCRIPTION
## Summary

- Restore cached headers before committing the response status.
- Add a regression test for headers on cache hits.

`net/http` freezes response headers when `WriteHeader` is called, so the old order could omit cached headers from the actual response.

## Test

`go test . ./utils`
